### PR TITLE
Regression: /opt/java_ext/ may not accessible in some case

### DIFF
--- a/recipes/jce.rb
+++ b/recipes/jce.rb
@@ -15,9 +15,24 @@ end
 package "unzip"
 package "curl"
 
-directory ::File.join(node["java_ext"]["jce_home"],jdk_version) do
+def ancestor_directories(target_dir)
+    def ancestor_directory_list(dir)
+      dirname = File.dirname(dir)
+      ['.', dirname].include?(dir) ? [] : (ancestor_directory_list(dirname) + [dir])
+    end
+
+    ancestor_directory_list(File.dirname(target_dir)).each {|dir| yield dir }
+end
+
+java_ext_home = ::File.join(node["java_ext"]["jce_home"],jdk_version)
+ancestor_directories java_ext_home do |dir|
+    directory dir do
+      mode "0755"
+    end
+end if node["java_ext"]["create_jce_home_recursively"]
+
+directory java_ext_home do
   mode "0755"
-  recursive node["java_ext"]["create_jce_home_recursively"]
 end
 
 directory ::File.join(node["java"]["java_home"], "jre", "lib", "security") do
@@ -44,6 +59,6 @@ end
 		not_if {::File.symlink? jar_path}
 	end
 	link jar_path do
-		to ::File.join(node["java_ext"]["jce_home"], jdk_version, jar)
+		to ::File.join(java_ext_home, jar)
 	end
 end

--- a/test/integration/jdk6/serverspec/localhost/jce_spec.rb
+++ b/test/integration/jdk6/serverspec/localhost/jce_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
+def java_home
+  File.expand_path("..", File.dirname(File.realpath(`which java`[0..-2])))
+end
+
 describe 'java_ext::jce' do
   context file('/opt/java_ext/jce/6/local_policy.jar') do
     it { should be_file }
@@ -8,12 +12,23 @@ describe 'java_ext::jce' do
     it { should be_file }
   end
 
-  context file('/usr/lib/jvm/java/jre/lib/security/local_policy.jar') do
+  context file("#{java_home}/jre/lib/security/local_policy.jar") do
     it { should be_symlink }
     it { should be_linked_to '/opt/java_ext/jce/6/local_policy.jar' }
   end
-  context file('/usr/lib/jvm/java/jre/lib/security/US_export_policy.jar') do
+  context file("#{java_home}/jre/lib/security/US_export_policy.jar") do
     it { should be_symlink }
     it { should be_linked_to '/opt/java_ext/jce/6/US_export_policy.jar' }
+  end
+end
+
+describe 'folder access mode' do
+  Dir.glob('/opt/java_ext/**/*').each do |item|
+      context file(item) do
+        it { should be_readable }
+        it { should be_executable } if File.directory? item
+        it { should be_owned_by 'root'}
+        it { should be_grouped_into 'root' }
+      end
   end
 end

--- a/test/integration/jdk7/serverspec/localhost/jce_spec.rb
+++ b/test/integration/jdk7/serverspec/localhost/jce_spec.rb
@@ -1,19 +1,34 @@
 require 'spec_helper'
 
+def java_home
+  File.expand_path("..", File.dirname(File.realpath(`which java`[0..-2])))
+end
+
 describe 'java_ext::jce' do
-  context file('/opt/java_ext/jce/7/local_policy.jar') do
+  context file('/opt/java_ext/jce/6/local_policy.jar') do
     it { should be_file }
   end
-  context file('/opt/java_ext/jce/7/US_export_policy.jar') do
+  context file('/opt/java_ext/jce/6/US_export_policy.jar') do
     it { should be_file }
   end
 
-  context file('/usr/lib/jvm/java/jre/lib/security/local_policy.jar') do
+  context file("#{java_home}/jre/lib/security/local_policy.jar") do
     it { should be_symlink }
-    it { should be_linked_to '/opt/java_ext/jce/7/local_policy.jar' }
+    it { should be_linked_to '/opt/java_ext/jce/6/local_policy.jar' }
   end
-  context file('/usr/lib/jvm/java/jre/lib/security/US_export_policy.jar') do
+  context file("#{java_home}/jre/lib/security/US_export_policy.jar") do
     it { should be_symlink }
-    it { should be_linked_to '/opt/java_ext/jce/7/US_export_policy.jar' }
+    it { should be_linked_to '/opt/java_ext/jce/6/US_export_policy.jar' }
+  end
+end
+
+describe 'folder access mode' do
+  Dir.glob('/opt/java_ext/**/*').each do |item|
+      context file(item) do
+        it { should be_readable }
+        it { should be_executable } if File.directory? item
+        it { should be_owned_by 'root'}
+        it { should be_grouped_into 'root' }
+      end
   end
 end

--- a/test/integration/jdk8/serverspec/localhost/jce_spec.rb
+++ b/test/integration/jdk8/serverspec/localhost/jce_spec.rb
@@ -1,19 +1,34 @@
 require 'spec_helper'
 
+def java_home
+  File.expand_path("..", File.dirname(File.realpath(`which java`[0..-2])))
+end
+
 describe 'java_ext::jce' do
-  context file('/opt/java_ext/jce/8/local_policy.jar') do
+  context file('/opt/java_ext/jce/6/local_policy.jar') do
     it { should be_file }
   end
-  context file('/opt/java_ext/jce/8/US_export_policy.jar') do
+  context file('/opt/java_ext/jce/6/US_export_policy.jar') do
     it { should be_file }
   end
 
-  context file('/usr/lib/jvm/java/jre/lib/security/local_policy.jar') do
+  context file("#{java_home}/jre/lib/security/local_policy.jar") do
     it { should be_symlink }
-    it { should be_linked_to '/opt/java_ext/jce/8/local_policy.jar' }
+    it { should be_linked_to '/opt/java_ext/jce/6/local_policy.jar' }
   end
-  context file('/usr/lib/jvm/java/jre/lib/security/US_export_policy.jar') do
+  context file("#{java_home}/jre/lib/security/US_export_policy.jar") do
     it { should be_symlink }
-    it { should be_linked_to '/opt/java_ext/jce/8/US_export_policy.jar' }
+    it { should be_linked_to '/opt/java_ext/jce/6/US_export_policy.jar' }
+  end
+end
+
+describe 'folder access mode' do
+  Dir.glob('/opt/java_ext/**/*').each do |item|
+      context file(item) do
+        it { should be_readable }
+        it { should be_executable } if File.directory? item
+        it { should be_owned_by 'root'}
+        it { should be_grouped_into 'root' }
+      end
   end
 end


### PR DESCRIPTION
Chef directory resource has this limitation (https://docs.chef.io/resource_directory.html#recursive-directories) where the `recursive` attribute only applies `group`, `mode` and `owner` attribute values to the leaf directory.

In recent code change, if the java_ext foder is created using chef directory resource with recursive flag turned on, the intermediate directory may not have mode/owner/group set up correctly, therefore we need to specify those explicitly as explanied in the chef document.

The wrongfully configured directory access info could cause java_ext jar files not be able to be accessed and loaded by JVM.